### PR TITLE
BatchNormImpl -> BatchNorm2dImpl

### DIFF
--- a/include/models/resnet.h
+++ b/include/models/resnet.h
@@ -174,7 +174,7 @@ ResNetImpl<Block>::ResNetImpl(
 				torch::kFanOut,
 				torch::kReLU);
 #ifdef WIN32 /** Initialize err*/				
-		else if (auto M = dynamic_cast<torch::nn::BatchNormImpl*>(module.get())) {
+		else if (auto M = dynamic_cast<torch::nn::BatchNorm2dImpl*>(module.get())) {
 			torch::nn::init::constant_(M->weight, 1);
 			torch::nn::init::constant_(M->bias, 0);
 		}


### PR DESCRIPTION
When using the latest version of libtorch, BatchNormImpl must be changed to BatchNorm2dImpl. #7 